### PR TITLE
fix: fall through to Python size calc when du lacks --exclude (macOS)

### DIFF
--- a/ubs
+++ b/ubs
@@ -575,24 +575,31 @@ dir_size_mb_filtered(){
   local dir="$1"
   local patterns_csv="${2:-}"
   local result=""
+  local has_du_exclude=0
   if need_cmd du; then
     local -a du_args=()
     if [[ -n "$patterns_csv" ]] && du --help 2>/dev/null | grep -q -- '--exclude'; then
+      has_du_exclude=1
       local -a pats=()
       IFS=',' read -r -a pats <<<"$patterns_csv"
       for pat in "${pats[@]}"; do
         [[ -n "$pat" ]] && du_args+=( "--exclude=$pat" )
       done
     fi
-    result=$(du -sm "${du_args[@]}" "$dir" 2>/dev/null | cut -f1)
-    if [[ "$result" =~ ^[0-9]+$ ]]; then
-      echo "$result"
-      return 0
-    fi
-    result=$(du -sk "${du_args[@]}" "$dir" 2>/dev/null | cut -f1)
-    if [[ "$result" =~ ^[0-9]+$ ]]; then
-      echo $((result / 1024))
-      return 0
+    # Only use du when either no patterns are needed OR du supports --exclude.
+    # On macOS, BSD du lacks --exclude, so we fall through to the Python path
+    # which handles exclusions correctly via fnmatch.
+    if [[ -z "$patterns_csv" || "$has_du_exclude" -eq 1 ]]; then
+      result=$(du -sm "${du_args[@]}" "$dir" 2>/dev/null | cut -f1)
+      if [[ "$result" =~ ^[0-9]+$ ]]; then
+        echo "$result"
+        return 0
+      fi
+      result=$(du -sk "${du_args[@]}" "$dir" 2>/dev/null | cut -f1)
+      if [[ "$result" =~ ^[0-9]+$ ]]; then
+        echo $((result / 1024))
+        return 0
+      fi
     fi
   fi
   if need_cmd python3; then


### PR DESCRIPTION
## Summary

Fixes #19 — on macOS, `dir_size_mb_filtered()` reports unfiltered directory sizes because BSD `du` doesn't support `--exclude`, causing the size guard to reject projects with large ignored directories (`target/`, `node_modules/`, etc.).

## Root Cause

The function correctly detects that `du` lacks `--exclude` on macOS, but then runs `du` anyway without any exclusions. Since `du` returns a valid integer, the function returns immediately — the Python fallback (which handles exclusions correctly via `fnmatch`) is never reached.

## Fix

Add a guard so the `du` path is only taken when either:
- No exclusion patterns were requested, OR
- `du` supports `--exclude`

When `du` can't apply exclusions, we fall through to the existing Python implementation which handles them correctly on all platforms.

## Impact

- **macOS**: Previously reported 28GB for a Rust project with 500KB of source code. Now correctly reports 8MB.
- **Linux**: No behavioral change — GNU `du` supports `--exclude`, so the guard passes and the same `du` path is taken as before.

## Verification

Tested on macOS 15.3 (Darwin 25.2.0, Apple Silicon):

```
# Before fix
$ ubs .
ℹ Scan size after ignores: 28085MB (limit 1000MB)
✗ Directory too large (after ignores): 28085MB exceeds limit of 1000MB

# After fix
$ ubs .
ℹ Scan size after ignores: 8MB (limit 1000MB)
# proceeds to scan normally
```