### PR TITLE
fix(cli): reject directory extra-args with a usage error, not 'file not found' (#88)

### DIFF
--- a/ubs
+++ b/ubs
@@ -1117,9 +1117,17 @@ prepare_files_workspace(){
     scan_root="$(dirname "$scan_root")"
   fi
 
-  # Resolve each path relative to scan_root; reject missing files
+  # Resolve each path relative to scan_root; reject missing files. A DIRECTORY
+  # here is a usage error, not a missing file: extra positional args form an
+  # explicit FILE list, and `ubs src/ test/` used to die with a misleading
+  # "file not found: test/" even though test/ exists (GH #88).
   local resolved=()
   local f rel
+  reject_dir_target(){
+    say "${RED}$X directories cannot be extra scan targets${RESET}: $1"
+    say "${DIM}extra positional args are an explicit FILE list; pass exactly one project directory per invocation, or list individual files${RESET}"
+    exit 2
+  }
   for f in "${SCAN_FILES[@]}"; do
     [[ -z "$f" ]] && continue
     if [[ "$f" == /* ]]; then
@@ -1127,6 +1135,8 @@ prepare_files_workspace(){
       if [[ -f "$f" ]]; then
         rel="${f#"$scan_root"/}"
         resolved+=("$rel")
+      elif [[ -d "$f" ]]; then
+        reject_dir_target "$f"
       else
         say "${RED}$X file not found${RESET}: $f"
         exit 2
@@ -1139,6 +1149,8 @@ prepare_files_workspace(){
       abs="$(cd "$(dirname "$f")" && pwd -P)/$(basename "$f")"
       rel="${abs#"$scan_root"/}"
       resolved+=("$rel")
+    elif [[ -d "$scan_root/$f" || -d "$f" ]]; then
+      reject_dir_target "$f"
     else
       say "${RED}$X file not found${RESET}: $f"
       exit 2


### PR DESCRIPTION
Addresses the error-message half of #88.

Extra positional args form an explicit FILE list (each `[[ -f ]]`-validated), so `ubs src/ test/` died with `file not found: test/` even though the directory exists — it reads as a filesystem bug rather than a usage error, and cost us a while in the field before source-diving revealed the contract. Directories are now detected at both resolve sites and rejected with a precise message naming the contract.

Behavior after the patch:

```
✗ directories cannot be extra scan targets: test/
extra positional args are an explicit FILE list; pass exactly one project directory per invocation, or list individual files
```

Whether to *support* multiple directory targets (union scan) is left as the feature decision in #88 — this just makes the current contract fail honestly.

Tested: `bash -n` + behavior run in a debian:trixie-slim container (dir-as-2nd-arg → the new message, exit 2; single-dir and file-list invocations unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)