### PR TITLE
fix(test): parse TOON totals once instead of summing every count field

### DIFF
--- a/test-suite/quality/test_rule_quality_harness.py
+++ b/test-suite/quality/test_rule_quality_harness.py
@@ -677,6 +677,34 @@ class RunManifestExpectationTest(unittest.TestCase):
             {"critical": 6, "warning": 8, "info": 10, "files": 12},
         )
 
+    def test_parse_toon_summary_uses_totals_block_once(self) -> None:
+        stdout = "\n".join(
+            [
+                "project: parser-proof",
+                "scanners[1]:",
+                "  - language: js",
+                "    files: 1",
+                "    critical: 2",
+                "    warning: 3",
+                "    info: 4",
+                "    findings[1]{severity,title}:",
+                "      warning,fixture",
+                "totals:",
+                "  files: 1",
+                "  critical: 2",
+                "  warning: 3",
+                "  info: 4",
+            ]
+        )
+
+        summary = rule_quality_harness.parse_toon_summary(stdout, "fixture")
+
+        self.assertIsNotNone(summary)
+        self.assertEqual(
+            summary["totals"],
+            {"files": 1, "critical": 2, "warning": 3, "info": 4},
+        )
+
     def test_parse_meta_runner_text_summary(self) -> None:
         summary = rule_quality_harness.parse_text_summary(
             "\n".join(

--- a/test-suite/run_manifest.py
+++ b/test-suite/run_manifest.py
@@ -472,22 +472,43 @@ def parse_sarif_summary(stdout: str, project_label: str) -> Optional[Dict[str, A
 def parse_toon_summary(stdout: str, project_label: str) -> Optional[Dict[str, Any]]:
     """Parse UBS --format=toon output to extract aggregate totals.
 
-    TOON output is YAML-like with a top-level ``scanners[N]:`` array whose
-    entries each expose ``critical``, ``warning``, ``info``, and ``files``
-    keys. Totals are the sum across scanners so the manifest's min/max
-    assertions continue to work regardless of format.
+    Prefer the top-level ``totals:`` mapping when present. Summing every
+    indented ``critical``/``warning``/``info``/``files`` line would count
+    per-scanner fields and the aggregate block twice (issue #115).
+    Fixtures that only list per-scanner fields still sum those values.
     """
     if "scanners[" not in stdout or "findings[" not in stdout:
         return None
-    totals = {"critical": 0, "warning": 0, "info": 0, "files": 0}
-    found_any = False
+    totals_keys = ("critical", "warning", "info", "files")
     pattern = re.compile(r"^\s+(critical|warning|info|files):\s*(\d+)\s*$")
+    header = re.compile(r"^totals:\s*$")
+    block: Dict[str, int] = {}
+    in_totals = False
     for line in stdout.splitlines():
-        m = pattern.match(line)
-        if not m:
+        if header.match(line):
+            in_totals = True
             continue
-        key = m.group(1)
-        totals[key] += int(m.group(2))
+        if in_totals:
+            if line and not line[:1].isspace():
+                break
+            match = pattern.match(line)
+            if match:
+                block[match.group(1)] = int(match.group(2))
+    if block:
+        totals = {key: 0 for key in totals_keys}
+        totals.update(block)
+        return {
+            "project": project_label,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "totals": totals,
+        }
+    totals = {key: 0 for key in totals_keys}
+    found_any = False
+    for line in stdout.splitlines():
+        match = pattern.match(line)
+        if not match:
+            continue
+        totals[match.group(1)] += int(match.group(2))
         found_any = True
     if not found_any:
         return None


### PR DESCRIPTION
## Summary

Stop the manifest TOON summary parser from counting per-scanner fields and the aggregate `totals` mapping twice.

- Fixes #115

## Changes

`parse_toon_summary` now prefers the top-level `totals:` block when present. Scanner-only fixtures without that block still sum per-scanner fields.

## Tests

- Existing `test_parse_toon_summary_sums_scanner_totals` (scanner-only fixture).
- New `test_parse_toon_summary_uses_totals_block_once` (producer-shaped document with both scanners and totals).

No encoder/runtime scan required for these unit checks. Distinct from #62 (encoder identity) and from #109's zero-files TOON cases.
